### PR TITLE
Layered timeline brackets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -349,19 +349,23 @@ html,body{
   background: #0ea5e9;
 }
 .duration-bracket.left::before {
-  left: -16px;
+  right: -16px;
+  left: auto;
   top: 0;
 }
 .duration-bracket.left::after {
-  left: -16px;
+  right: -16px;
+  left: auto;
   bottom: 0;
 }
 .duration-bracket.right::before {
-  right: -16px;
+  left: -16px;
+  right: auto;
   top: 0;
 }
 .duration-bracket.right::after {
-  right: -16px;
+  left: -16px;
+  right: auto;
   bottom: 0;
 }
 

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -119,13 +119,18 @@ export default function Resume() {
           const cardWidth     = 280;
           const laneGap       = 16;
           const baseConnector = 60;
+          const bracketSpacing = 8;
           const connectorLen  = baseConnector + laneIndex * (cardWidth + laneGap);
 
           // inline styles
+          const bracketLeft = side === "left"
+            ? `calc(50% - 2% - ${laneIndex * bracketSpacing}px)`
+            : `calc(50% + 2% + ${laneIndex * bracketSpacing}px)`;
+
           const bracketStyle = {
             position: "absolute",
             top: `${nudged}%`,
-            left: side === "left" ? "calc(50% - 2%)" : "calc(50% + 2%)",
+            left: bracketLeft,
             transform: "translateX(-50%)",
             height: exp.end
               ? `${toPct(Date.parse(exp.end)) - startPct}%`
@@ -133,8 +138,8 @@ export default function Resume() {
           };
 
           const cardLeft = side === "left"
-            ? `calc(50% - 2% - ${connectorLen + cardWidth}px)`
-            : `calc(50% + 2% + ${connectorLen}px)`;
+            ? `calc(50% - 2% - ${laneIndex * bracketSpacing}px - ${connectorLen + cardWidth}px)`
+            : `calc(50% + 2% + ${laneIndex * bracketSpacing}px + ${connectorLen}px)`;
 
           return (
             <React.Fragment key={i}>


### PR DESCRIPTION
## Summary
- reverse orientation of duration brackets so they point toward the spine
- offset each bracket horizontally based on lane index to avoid overlaps

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e8123584832bb11bc0143b074916