### PR TITLE
Fix connector alignment in resume timeline

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -65,7 +65,7 @@ export default function Resume() {
         const dist      = Math.abs(c - mid);
         const ratio     = Math.max(0, 1 - dist / (mid + r.height));
         const scale     = 0.8 + ratio * 0.4;
-        card.style.transform = `translateY(-50%) scale(${scale})`;
+        card.style.transform = `scale(${scale})`;
         const dynamic = base + (cardWidth * (1 - scale)) / 2;
         connector.style.width = `${dynamic}px`;
       });


### PR DESCRIPTION
## Summary
- keep resume cards centered by removing extra vertical translate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848eb057e7c832ba0a11da7247a394f