### PR TITLE
Fix hero background without binary asset

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,6 +27,18 @@ html,body{
   padding-top: 20px;
   padding-bottom: 0px;
 }
+.backgroundImg {
+  background-image: url('https://via.placeholder.com/1920x1080');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
 /* end BootStrap */
 
 /* NAV */

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -13,7 +13,7 @@ class Home extends Component{
 
   render(){
     return (
-        <div className="jumbotron jumboSpacing">   
+        <div className="jumbotron jumbotron-fluid jumboSpacing">
           <div className="backgroundImg">       
           <FadeIn delay={400} transitionDuration={4000}>
             <div className="row">
@@ -24,13 +24,11 @@ class Home extends Component{
           {/* </FadeIn>
           <FadeIn delay={2000} transitionDuration={4000}> */}
           <div className="row">
-            <div className="col-md-4"></div>
-            <div className="col-md-4">
+            <div className="col-md-12 text-center">
               <h3 className="textAnimate">My name is Logan Moss,</h3>
               <h3 className="textAnimate">and I am a Fullstack Developer </h3>
               <h3 className="textAnimate">based in San Francisco.</h3>
             </div>
-            <div className="col-md-4"></div>
           </div>
             
             <hr className="my-4"></hr>


### PR DESCRIPTION
## Summary
- tweak Home jumbotron to be fluid
- use a remote placeholder image for hero background
- remove binary placeholder image asset

## Testing
- `npm test --silent --forceExit` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f4dba334832b94ba14c6ce074c98