### PR TITLE
Set site background image

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,7 +18,9 @@ body {
 
 html,body{
   height:100%;
-  background-color: #e9ecef;
+  /* Set a fixed background image that covers the page. Replace the URL with your own photo */
+  background: url('https://via.placeholder.com/1920x1080') no-repeat center center fixed;
+  background-size: cover;
   /* overflow: hidden; */
 }
 
@@ -27,11 +29,12 @@ html,body{
   padding-top: 20px;
   padding-bottom: 0px;
 }
+.jumbotron {
+  background-color: transparent;
+}
 .backgroundImg {
-  background-image: url('https://via.placeholder.com/1920x1080');
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
+  /* Allow the page background to show through */
+  background: transparent;
   min-height: 100vh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- remove placeholder `me.png`
- use remote placeholder for the page-wide background and document where to replace it
- keep the jumbotron transparent so the background shows through

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fa996fa8832b84a1c94e3139002c