### PR TITLE
Add floating Experience label

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -570,3 +570,15 @@ html,body{
   cursor: pointer;
   font-size: 1.2rem;
 }
+
+/* Floating experience label on Resume page */
+.experience-box {
+  position: fixed;
+  top: 5rem; /* space below navigation */
+  left: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  z-index: 1100;
+  overflow-y: auto;
+}

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -135,6 +135,7 @@ export default function Resume() {
 
   return (
     <>
+    <div className="experience-box">Experience</div>
     <div className="timeline">
       {/* Spine */}
       <div className="spine" />


### PR DESCRIPTION
## Summary
- display a fixed 'Experience' box on the resume page
- style the floating experience box

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ff616294832b98f6ddb9f3b42229