### PR TITLE
Adjust resume experience label

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -579,6 +579,6 @@ html,body{
   background: rgba(255, 255, 255, 0.9);
   padding: 0.5rem 1rem;
   border-radius: 4px;
-  z-index: 1100;
-  overflow-y: auto;
+  z-index: 0; /* sit on the same layer as the timeline */
+  pointer-events: none; /* avoid blocking timeline interactions */
 }


### PR DESCRIPTION
## Summary
- move the Experience label to the same layer as the timeline
- prevent it from blocking timeline interactions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490147e2d4832b9c46ab4157f998f4