### PR TITLE
Fix background margin on homepage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,8 +24,8 @@ html,body{
 
 /* BootStrap */
 .jumboSpacing {
-  padding-top: 20px;
-  padding-bottom: 0px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 .backgroundImg {
   background-image: url('./low_contrast_linen.png');


### PR DESCRIPTION
## Summary
- remove top padding on home jumbotron to eliminate white space

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849048f0b84832ba5ee5863cd92d2c4