### PR TITLE
Fix homepage top spacing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,8 +14,8 @@ body {
   text-align: center;
   font-family: 'Montserrat', sans-serif;
   /* background-color: #DDDFDF; */
-  margin-top: -80px;
-  padding-top: 80px;
+  margin-top: 0;
+  padding-top: 0;
 }
 
 html,body{


### PR DESCRIPTION
## Summary
- remove negative margin hack from App container to eliminate top whitespace on homepage

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849085c08f0832ba629b58ea5226525