### PR TITLE
Adjust jumbotron layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,8 +38,21 @@ html,body{
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.introHeader {
+  min-height: 100vh;
+  display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%;
+}
+
+.centerTextDiv {
+  text-align: center;
+  width: 100%;
 }
 
 /* end BootStrap */

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -14,7 +14,10 @@ class Home extends Component{
   render(){
     return (
         <div className="jumbotron jumbotron-fluid jumboSpacing">
-          <div className="backgroundImg">       
+          <div className="backgroundImg">
+            <div className="introHeader">
+              <div className="centerTextDiv">Header Placeholder</div>
+            </div>
           <FadeIn delay={400} transitionDuration={4000}>
             <div className="row">
               <div className="col-md-12">


### PR DESCRIPTION
## Summary
- add placeholder space for a large header
- move existing jumbotron text down

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490c424af8832babefe747c294489e