### PR TITLE
Fix background width on homepage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,8 +31,9 @@ html,body{
 }
 .backgroundImg {
   background-image: url('../public/backgroundimagewpaint.png');
-  background-size: cover;
-  background-position: center;
+  /* Ensure the full width of the image is visible */
+  background-size: 100% auto;
+  background-position: top center;
   background-repeat: no-repeat;
   background-attachment: scroll;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- display the homepage background image at full width

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491699d994832bbbf970838e8b333f