### PR TITLE
Fix overlapping timeline cards

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -183,7 +183,8 @@ export default function Resume() {
           const midPct   = startPct + (endPct - startPct) / 2;
 
           // assign to the first lane that is free and spaced out
-          const minGap = 5; // % between event centers
+          // increased from 5 to 15 so larger cards don't overlap
+          const minGap = 15; // % between event centers
           const laneData = lanes[side];
           let laneIndex = laneData.findIndex(({ endTime, mid }) => {
             return endTime <= start && Math.abs(midPct - mid) >= minGap;


### PR DESCRIPTION
## Summary
- increase minimum lane spacing to avoid timeline card overlap

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492e7f084c832b8e72c49c7e44e0d3