### PR TITLE
Fix Resume page modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -639,12 +639,16 @@ html,body{
   max-width: 500px;
   width: 90%;
   color: #1f2937;
+  position: relative;
 }
 
 .modal-close {
-  float: right;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
   cursor: pointer;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
+  line-height: 1;
 }
 
 /* Floating experience label on Resume page */

--- a/src/components/Resume/ExperienceModal.js
+++ b/src/components/Resume/ExperienceModal.js
@@ -1,9 +1,11 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import "../../App.css";
 
 export default function ExperienceModal({ exp, onClose }) {
   if (!exp) return null;
-  return (
+
+  const modalContent = (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-close" onClick={onClose}>&times;</div>
@@ -14,4 +16,6 @@ export default function ExperienceModal({ exp, onClose }) {
       </div>
     </div>
   );
+
+  return ReactDOM.createPortal(modalContent, document.body);
 }


### PR DESCRIPTION
## Summary
- show resume modals using a portal so they always display
- tweak modal styles and close button placement

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493301876c832b800f939e4df012b2