### PR TITLE
Fix modals not rendering

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,5 +19,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/src/components/Resume/ExperienceModal.js
+++ b/src/components/Resume/ExperienceModal.js
@@ -17,5 +17,6 @@ export default function ExperienceModal({ exp, onClose }) {
     </div>
   );
 
-  return ReactDOM.createPortal(modalContent, document.body);
+  const modalRoot = document.getElementById("modal-root");
+  return modalRoot ? ReactDOM.createPortal(modalContent, modalRoot) : null;
 }


### PR DESCRIPTION
## Summary
- allocate a dedicated DOM node for modals
- mount `ExperienceModal` into the new `modal-root`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684933c381d8832b9397f3eafd608556