### PR TITLE
Fix modal display overlapping with Bootstrap style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -632,7 +632,7 @@ html,body{
   z-index: 2000;
 }
 
-.modal {
+.experience-modal {
   background: #fff;
   padding: 1rem;
   border-radius: 8px;

--- a/src/components/Resume/ExperienceModal.js
+++ b/src/components/Resume/ExperienceModal.js
@@ -7,7 +7,7 @@ export default function ExperienceModal({ exp, onClose }) {
 
   const modalContent = (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+      <div className="experience-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-close" onClick={onClose}>&times;</div>
         <h3>{exp.title}</h3>
         <p className="company">{exp.company}</p>


### PR DESCRIPTION
## Summary
- avoid Bootstrap CSS conflict for resume modals

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684934831f54832b8610c6aeeb805685