### PR TITLE
Add career/education toggle on resume page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -265,6 +265,20 @@ html,body{
   margin-right: 5%;
 }
 
+.resumeToggle {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.resumeTab {
+  cursor: pointer;
+  margin: 0 0.5rem;
+}
+
+.resumeTab.active {
+  font-weight: bold;
+}
+
 
 /* Animation */
 

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -1,72 +1,96 @@
 import React, { Component } from 'react';
 import "../../App.css";
 import FadeIn from 'react-fade-in';
+
+const experiences = [
+  {
+    img: "https://www.insidehighered.com/sites/default/server_files/styles/large-copy/public/media/trilogy-logo-2016-horizontal-for-light-bg_0.png?itok=M6IdyMFS",
+    alt: "UCB logo",
+    titles: ["Full Stack Flex TA", "Data Analytics TA"],
+    dates: ["July 2020 - Present"]
+  },
+  {
+    img: "https://www.wing.vc/uploads/images/companies/Bungalow_Full_BlackColor.png",
+    alt: "bungalowgo",
+    titles: ["Data Associate - Contract"],
+    dates: ["Sep 2019 - Oct 2019"]
+  },
+  {
+    img: "https://myusf.usfca.edu/sites/default/files/images/OMC/usf_f_h2_2c_rgb_360.png",
+    alt: "usf logo",
+    titles: ["Field Support", "Level 2 Operations", "System Admin", "Help Desk Specialist"],
+    dates: [
+      "Aug 2019 - Oct 2019",
+      "Jun 2019 - Aug 2019",
+      "Aug 2016 - Oct 2018",
+      "Feb 2016 - Aug 2016"
+    ]
+  }
+];
+
+const educationexp = [
+  {
+    img: "https://davidmitroff.com/wp-content/uploads/2015/11/UC-Berkeley-Extension.png",
+    alt: "UCB logo",
+    titles: ["FullStack Development Bootcamp"],
+    dates: ["Graduation Date: May 2020"]
+  },
+  {
+    img: "https://myusf.usfca.edu/sites/default/files/images/OMC/usf_f_h2_2c_rgb_360.png",
+    alt: "usf logo",
+    titles: ["Major: Advertising", "Minor: Computer Science"],
+    dates: ["Graduation Date: May 2019"]
+  }
+];
 // const PDFImage = require("pdf-image").PDFImage;
 // import PDFViewer from "pdf-viewer-reactjs"
 // pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
 class Resume extends Component {
- render() {
-  return (
-    
+  state = { view: 'career' };
+
+  renderItem(item) {
+    return (
+      <div className="skillsAnimate resumeItem" key={item.titles[0]}>
+        <img src={item.img} width={"30%"} alt={item.alt}></img>
+        <div className="resumeFlexBody">
+          <div>
+            {item.titles.map((t, i) => <h5 key={i}>{t}</h5>)}
+          </div>
+          <div>
+            {item.dates.map((d, i) => <h5 key={i}>{d}</h5>)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    const current = this.state.view === 'career' ? experiences : educationexp;
+    return (
       <div className="container resumeContainer">
+        <div className="resumeToggle">
+          <span
+            className={`resumeTab${this.state.view === 'career' ? ' active' : ''}`}
+            onClick={() => this.setState({ view: 'career' })}
+          >
+            Career
+          </span>
+          <span> | </span>
+          <span
+            className={`resumeTab${this.state.view === 'education' ? ' active' : ''}`}
+            onClick={() => this.setState({ view: 'education' })}
+          >
+            Education
+          </span>
+        </div>
         <FadeIn delay={300} transitionDuration={1000}>
-        <div className="skillsAnimate resumeItem">
-            <img src={"https://www.insidehighered.com/sites/default/server_files/styles/large-copy/public/media/trilogy-logo-2016-horizontal-for-light-bg_0.png?itok=M6IdyMFS"} width={"30%"} alt="UCB logo"></img>
-            <div className="resumeFlexBody">
-              <div>
-                <h5>Full Stack Flex TA</h5>
-                <h5>Data Analytics TA</h5>
-              </div>
-              <h5>July 2020 - Present</h5>
-            </div>
-        </div>
-        <div className="skillsAnimate resumeItem">
-            <img src={"https://davidmitroff.com/wp-content/uploads/2015/11/UC-Berkeley-Extension.png"} width={"30%"} alt="UCB logo"></img>
-            <div className="resumeFlexBody">
-              <h5>FullStack Development Bootcamp</h5>
-              <h5><strong>Graduation Date:</strong> May 2020</h5>
-            </div>
-        </div>
-        <div className="skillsAnimate resumeItem">
-            <img src={"https://myusf.usfca.edu/sites/default/files/images/OMC/usf_f_h2_2c_rgb_360.png"} width={"30%"} alt="usf logo"></img>
-            <div className="resumeFlexBody">
-              <div>
-                <h5><strong>Major:</strong> Advertising</h5>
-                <h5><strong>Minor:</strong> Computer Science</h5>
-              </div>
-              <h5><strong>Graduation Date:</strong> May 2019</h5>
-            </div>
-        </div>
-        <div className="skillsAnimate resumeItem">
-            <img src={"https://www.wing.vc/uploads/images/companies/Bungalow_Full_BlackColor.png"} width={"30%"} alt="bungalowgo"></img>
-            <div className="resumeFlexBody">
-              <h5>Data Associate - Contract</h5>
-              <h5>Sep 2019 - Oct 2019</h5>
-            </div>
-        </div>
-        <div className="skillsAnimate resumeItem">
-        <img src={"https://myusf.usfca.edu/sites/default/files/images/OMC/usf_f_h2_2c_rgb_360.png"} width={"30%"} alt="usf logo"></img>
-            <div className="resumeFlexBody">
-              <div>
-                <h5>Field Support</h5>
-                <h5>Level 2 Operations</h5>
-                <h5>System Admin</h5>
-                <h5>Help Desk Specialist</h5>
-              </div>
-              <div>
-                <h5>Aug 2019 - Oct 2019</h5>
-                <h5>Jun 2019 - Aug 2019</h5>
-                <h5>Aug 2016 - Oct 2018</h5>
-                <h5>Feb 2016 - Aug 2016</h5>
-              </div>
-            </div>
-        </div>
+          {current.map(item => this.renderItem(item))}
         </FadeIn>
       </div>
-    
-  )
- }
+
+    );
+  }
 }
 
 export default Resume;


### PR DESCRIPTION
## Summary
- add constant arrays for career and education experiences
- allow toggling between career and education views in `Resume`
- style new toggle controls

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493d147bd4832b854fc9b7d31a9069