### PR TITLE
Add resume section toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -662,3 +662,19 @@ html,body{
   z-index: 0; /* sit on the same layer as the timeline */
   pointer-events: none; /* avoid blocking timeline interactions */
 }
+
+/* Toggle buttons on Resume page */
+.resume-toggle {
+  text-align: center;
+  margin-top: 1rem;
+  font-family: 'Montserrat', sans-serif;
+}
+
+.resume-toggle span {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.resume-toggle span.active {
+  text-decoration: underline;
+}

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -132,10 +132,14 @@ const experiences = [
 
 export default function Resume() {
   const [selected, setSelected] = useState(null);
+  const [view, setView] = useState("career");
+
+  const expArray = view === "career" ? experiences : educationexp;
+
   // 1) Chronologically sort
   const sorted = useMemo(
-    () => experiences.slice().sort((a, b) => Date.parse(a.start) - Date.parse(b.start)),
-    []
+    () => expArray.slice().sort((a, b) => Date.parse(a.start) - Date.parse(b.start)),
+    [expArray]
   );
 
   // 2) Compute timeline bounds with one year buffer
@@ -196,10 +200,25 @@ export default function Resume() {
       window.removeEventListener("scroll", fn);
       window.removeEventListener("resize", fn);
     };
-  }, []);
+  }, [sorted]);
 
   return (
     <>
+    <div className="resume-toggle">
+      <span
+        className={view === "career" ? "active" : ""}
+        onClick={() => setView("career")}
+      >
+        Career
+      </span>
+      <span> | </span>
+      <span
+        className={view === "education" ? "active" : ""}
+        onClick={() => setView("education")}
+      >
+        Education
+      </span>
+    </div>
     <div className="timeline">
       {/* Spine */}
       <div className="spine" />


### PR DESCRIPTION
## Summary
- add simple toggle for career vs. education timelines
- make timeline animation effect react to data changes
- style toggle links

## Testing
- `npm test -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493eb07034832b8bd624be0a1ab3c9