### PR TITLE
Adjust resume toggle positioning

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -388,9 +388,14 @@ html,body{
 }
 
 /* ─── Timeline Container ───────────────────────────── */
-.timeline {
+.timeline-wrapper {
   position: relative;
   margin-top: 5rem;
+}
+
+.timeline {
+  position: relative;
+  margin-top: 0;
   height: 180vh;      /* adjust scroll length */
   width: 100%;
   background: #e9ecef;
@@ -666,7 +671,11 @@ html,body{
 /* Toggle buttons on Resume page */
 .resume-toggle {
   text-align: center;
-  margin-top: 1rem;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 20px; /* roughly 20px gap above the timeline */
   font-family: 'Montserrat', sans-serif;
 }
 

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -204,22 +204,23 @@ export default function Resume() {
 
   return (
     <>
-    <div className="resume-toggle">
-      <span
-        className={view === "career" ? "active" : ""}
-        onClick={() => setView("career")}
-      >
-        Career
-      </span>
-      <span> | </span>
-      <span
-        className={view === "education" ? "active" : ""}
-        onClick={() => setView("education")}
-      >
-        Education
-      </span>
-    </div>
-    <div className="timeline">
+    <div className="timeline-wrapper">
+      <div className="resume-toggle">
+        <span
+          className={view === "career" ? "active" : ""}
+          onClick={() => setView("career")}
+        >
+          Career
+        </span>
+        <span> | </span>
+        <span
+          className={view === "education" ? "active" : ""}
+          onClick={() => setView("education")}
+        >
+          Education
+        </span>
+      </div>
+      <div className="timeline">
       {/* Spine */}
       <div className="spine" />
 
@@ -318,6 +319,7 @@ export default function Resume() {
         );
         });
       })()}
+      </div>
     </div>
     <ExperienceModal exp={selected} onClose={() => setSelected(null)} />
     </>


### PR DESCRIPTION
## Summary
- move career/education toggle inside new `.timeline-wrapper`
- position toggle absolutely so it's about 20px above the timeline

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493fd1bc9c832b8bd41240a340bd81