### PR TITLE
Add fade animation for resume toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -400,6 +400,11 @@ html,body{
   width: 100%;
   background: #e9ecef;
   overflow-x: hidden;
+  transition: opacity 0.3s ease;
+}
+
+.timeline.fading {
+  opacity: 0;
 }
 
 /* ─── Central Spine + Ticks ───────────────────────── */

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -133,6 +133,16 @@ const experiences = [
 export default function Resume() {
   const [selected, setSelected] = useState(null);
   const [view, setView] = useState("career");
+  const [fading, setFading] = useState(false);
+
+  const handleToggle = (newView) => {
+    if (newView === view) return;
+    setFading(true);
+    setTimeout(() => {
+      setView(newView);
+      setFading(false);
+    }, 300);
+  };
 
   const expArray = view === "career" ? experiences : educationexp;
 
@@ -208,19 +218,19 @@ export default function Resume() {
       <div className="resume-toggle">
         <span
           className={view === "career" ? "active" : ""}
-          onClick={() => setView("career")}
+          onClick={() => handleToggle("career")}
         >
           Career
         </span>
         <span> | </span>
         <span
           className={view === "education" ? "active" : ""}
-          onClick={() => setView("education")}
+          onClick={() => handleToggle("education")}
         >
           Education
         </span>
       </div>
-      <div className="timeline">
+      <div className={`timeline ${fading ? "fading" : ""}`}>
       {/* Spine */}
       <div className="spine" />
 


### PR DESCRIPTION
## Summary
- animate the resume timeline fade on toggle
- handle toggle logic for career and education views

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494207cf58832b9447ec0409fef9d1