### PR TITLE
Fix timeline connector scaling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -500,7 +500,8 @@ html,body{
 .timeline-item .connector {
   position: absolute;
   top: 50%;
-  transform: translateY(-50%);
+  transform: translateY(-50%) scaleX(1);
+  transform-origin: left;
   height: 2px;
   background: #0ea5e9;
   z-index: -1;
@@ -509,10 +510,12 @@ html,body{
 /* connectors on left‐side events extend rightwards */
 .timeline-item.left .connector {
   left: 100%;
+  transform-origin: right;
 }
 /* connectors on right‐side events extend leftwards */
 .timeline-item.right .connector {
   right: 100%;
+  transform-origin: left;
 }
 
 /* hide any older pseudo‐dots */

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -200,8 +200,9 @@ export default function Resume() {
         const ratio     = Math.max(0, 1 - dist / (mid + r.height));
         const scale     = 0.8 + ratio * 0.4;
         card.style.transform = `scale(${scale})`;
-        const dynamic = base + (cardWidth * (1 - scale)) / 2;
-        connector.style.width = `${dynamic}px`;
+        const dynamic  = base + (cardWidth * (1 - scale)) / 2;
+        const factor   = dynamic / base;
+        connector.style.transform = `translateY(-50%) scaleX(${factor})`;
       });
     };
     fn();


### PR DESCRIPTION
## Summary
- anchor connector lines to the timeline
- scale connectors from the timeline side when scrolling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684952e50630832ba3440839c451e9ac