### PR TITLE
Add floating social links and clean up GitHub nav link

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -734,3 +734,27 @@ html,body{
   filter: grayscale(80%);
 }
 
+
+/* Floating social links */
+.floating-links {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 1050;
+}
+
+.floating-button {
+  margin-top: 5px;
+  background-color: black;
+  color: white;
+  border-radius: 6px;
+  padding: 8px;
+  text-decoration: none;
+}
+
+.floating-button:hover {
+  opacity: 0.8;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Home from "./components/Home"
 import Contact from "./components/Contact/Contact"
 import Projects from "./components/Projects/Projects"
 import Resume from "./components/Resume/Resume"
+import FloatingLinks from "./components/FloatingLinks"
 import {
   BrowserRouter as Router,
   Switch,
@@ -25,6 +26,7 @@ class App extends Component {
             <Route path="/projects" component={Projects}/>
             <Route path="/contact" component={Contact}/>
           </Switch>
+          <FloatingLinks />
         </div>
       </Router>
     );

--- a/src/components/FloatingLinks.js
+++ b/src/components/FloatingLinks.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import '../App.css';
+
+function FloatingLinks() {
+  return (
+    <div className="floating-links">
+      <a
+        href="https://www.linkedin.com/in/loganmoss/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="floating-button"
+      >
+        <i className="fab fa-linkedin"></i>
+      </a>
+      <a
+        href="https://github.com/Loganrdj"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="floating-button"
+      >
+        <i className="fab fa-github"></i>
+      </a>
+      <a href="mailto:lrdjmoss@gmail.com" className="floating-button">
+        <i className="fas fa-envelope"></i>
+      </a>
+    </div>
+  );
+}
+
+export default FloatingLinks;

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -114,11 +114,6 @@ class Home extends Component{
                   <button className="buttonClass buttonAnimation">Contact</button>
                 </Link>
               </div>
-              <div className="col-md-3 col-lg-3 col-sm-3 col-xl-3 col-xs-3">
-                <div className="nav-link">
-                  <button className="buttonClass buttonAnimation">Github</button>
-                </div>
-              </div>
             </div>
           </div>
           <hr className="my-4"></hr>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -25,9 +25,6 @@ function Nav() {
       </button>
 
       <ul className={`customNavLinks ${menuOpen ? "showMobileMenu" : ""}`}>
-        <a href="https://github.com/Loganrdj" className="customNavLink" onClick={closeMenu}>
-          <li className="customNavLink">Github</li>
-        </a>
         <Link to="/resume" className="customNavLink" onClick={closeMenu}>
           <li className="customNavLink">Resume</li>
         </Link>


### PR DESCRIPTION
## Summary
- remove GitHub link from navbar and homepage
- add floating social link buttons for LinkedIn, GitHub and Email

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684956b8b4b0832b909d270afc1672dd