### PR TITLE
Refactor home layout and add scroll snap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -51,7 +51,9 @@ body {
 html,body{
   height:100%;
   background-color: #e9ecef;
-  /* overflow: hidden; */
+  scroll-snap-type: y mandatory;
+  scroll-behavior: smooth;
+  overflow-y: scroll;
 }
 
 /* BootStrap */
@@ -776,4 +778,18 @@ html,body{
 
 .floating-button:hover {
   opacity: 0.8;
+}
+
+/* scroll snapping sections */
+.snap-section {
+  scroll-snap-align: start;
+}
+
+.homeContent {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
 }

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -14,13 +14,15 @@ class Home extends Component{
   render(){
     return (
         <div className="jumbotron jumbotron-fluid jumboSpacing">
-          <div className="backgroundImg">
+          <div className="backgroundImg snap-section">
             <div className="introHeader">
               <div className="centerTextDiv">
                 <p className="firstName">Logan</p>
                 <p className="lastName">Moss</p>
               </div>
             </div>
+          </div>
+          <div className="homeContent snap-section">
           <FadeIn delay={400} transitionDuration={4000}>
             <div className="row">
               <div className="col-md-12">


### PR DESCRIPTION
## Summary
- split Home background image section from main content
- add scroll snapping styles

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d85fead0832b85789ef5dde74642