### PR TITLE
Fix hero text position and responsive background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,8 +63,8 @@ html,body{
 }
 .backgroundImg {
   background-image: url('../public/backgroundimagewpaint.png');
-  /* Ensure the full width of the image is visible */
-  background-size: 110% auto;
+  /* Scale with the viewport while keeping the same ratio */
+  background-size: cover;
   background-position: top center;
   background-repeat: no-repeat;
   background-attachment: scroll;
@@ -84,9 +84,11 @@ html,body{
 }
 
 .centerTextDiv {
-  position: absolute;   /* pull it out of the normal flow */
+  /* Keep the name fixed so it stays in place while scrolling */
+  position: fixed;
   top: 0;
   left: 0;
+  z-index: 1000;
 
   /* size it to exactly the top-left quarter */
   width: 40%;


### PR DESCRIPTION
## Summary
- keep hero background image responsive to viewport size
- fix "Logan Moss" text so it stays pinned when scrolling

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d9909bbc832ba24db4a9a64c91c6