### PR TITLE
Adjust hero header scrolling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,11 +84,10 @@ html,body{
 }
 
 .centerTextDiv {
-  /* Keep the name fixed so it stays in place while scrolling */
-  position: fixed;
+  /* Pull the hero text out of the normal flow but let it scroll */
+  position: absolute;
   top: 0;
   left: 0;
-  z-index: 1000;
 
   /* size it to exactly the top-left quarter */
   width: 40%;
@@ -106,6 +105,7 @@ html,body{
 .firstName {
   top: 1rem;             /* ↗ keep “Moss” up at the top */
   right: 1rem;
+  font-size: clamp(4rem, 10vw, 7rem);
 }
 .lastName {
   /* font-family: 'Digitag', sans-serif; */


### PR DESCRIPTION
## Summary
- make hero header text scroll with the page rather than stay fixed
- keep hero text responsive on smaller screens

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e00d42fc832b89f5e20b7726bb6d