### PR TITLE
Add rotating skill display with anchor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -783,6 +783,37 @@ html,body{
   opacity: 0.8;
 }
 
+/* Rotating skill text on home page */
+.skill-flash-container {
+  position: fixed;
+  bottom: 100px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  z-index: 1050;
+  font-family: 'Montserrat', sans-serif;
+}
+
+.skill-flash-text {
+  background: rgba(255, 255, 255, 0.85);
+  padding: 4px 8px;
+  border-radius: 4px;
+  animation: fadeSkill 1s ease-in-out infinite;
+}
+
+.see-more-link {
+  margin-top: 4px;
+  color: black;
+  text-decoration: underline;
+  font-size: 0.9rem;
+}
+
+@keyframes fadeSkill {
+  0%, 100% { opacity: 0; }
+  50% { opacity: 1; }
+}
+
 /* scroll snapping sections */
 .snap-section {
   scroll-snap-align: start;

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -5,13 +5,40 @@ import { Link } from 'react-router-dom';
 // import SkillsCard from './SkillsCard/SkillsCard';
 import skills from './SkillsCard/skills.json'
 
+const rotatingSkillList = [
+  'JavaScript',
+  'Python',
+  'Ruby',
+  'Go',
+  'Java',
+  'C++'
+];
+
 class Home extends Component{
 
   state = {
-    skills
+    skills,
+    rotatingSkills: [],
+    currentSkillIndex: 0
+  }
+
+  componentDidMount() {
+    const shuffled = [...rotatingSkillList].sort(() => Math.random() - 0.5);
+    this.setState({ rotatingSkills: shuffled });
+    this.interval = setInterval(() => {
+      this.setState(prev => ({
+        currentSkillIndex: (prev.currentSkillIndex + 1) % shuffled.length
+      }));
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
   }
 
   render(){
+    const { rotatingSkills, currentSkillIndex } = this.state;
+    const currentSkill = rotatingSkills[currentSkillIndex];
     return (
         <div className="jumbotron jumbotron-fluid jumboSpacing">
           <div className="backgroundImg snap-section">
@@ -21,6 +48,11 @@ class Home extends Component{
                 <p className="lastName">Moss</p>
               </div>
             </div>
+            <div className="skill-flash-container">
+              <div className="skill-flash-text">{currentSkill}</div>
+              <a href="#bg-bottom" className="see-more-link">See more</a>
+            </div>
+            <a id="bg-bottom"></a>
           </div>
           <div className="homeContent snap-section">
           <FadeIn delay={400} transitionDuration={4000}>


### PR DESCRIPTION
## Summary
- display a rotating skill on the hero background
- include a link to the bottom of the hero image
- style the rotating skill and fade animation

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eb1aacd4832baf93ea0dfd1b7993