### PR TITLE
Fix skill flash position

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -69,6 +69,7 @@ html,body{
   background-repeat: no-repeat;
   background-attachment: scroll;
   min-height: 100vh;
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;


### PR DESCRIPTION
## Summary
- adjust `.backgroundImg` so skill container positions relative to the hero section

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fdb416a4832b88a63a1acb0d5a57