### PR TITLE
Fix resume zoom effect

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -191,7 +191,6 @@ export default function Resume() {
     const fn = () => {
       const mid = window.innerHeight / 2;
       items.forEach((el) => {
-        const card      = el.querySelector(".card");
         const connector = el.querySelector(".connector");
         const base      = parseFloat(el.dataset.baseconnector);
         const r         = el.getBoundingClientRect();
@@ -199,7 +198,7 @@ export default function Resume() {
         const dist      = Math.abs(c - mid);
         const ratio     = Math.max(0, 1 - dist / (mid + r.height));
         const scale     = 0.8 + ratio * 0.4;
-        card.style.transform = `scale(${scale})`;
+        el.style.transform = `translateY(-50%) scale(${scale})`;
         const dynamic  = base + (cardWidth * (1 - scale)) / 2;
         const factor   = dynamic / base;
         connector.style.transform = `translateY(-50%) scaleX(${factor})`;


### PR DESCRIPTION
## Summary
- restore translate+scale effect on resume timeline items so middle item grows during scroll

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0a9198b8832b8503dd8b7d1d2fc9