### PR TITLE
Fix resume zoom and constrain project grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -282,23 +282,35 @@ html,body{
 .projects-container {
   margin-top: 20px;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  justify-content: center;
   width: 100%;
 }
 
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   grid-auto-rows: 1fr;
   gap: 1.5rem;
   width: 100%;
   padding: 8%;
+  max-width: 1000px;
 }
 
 @media (max-width: 768px) {
   .projects-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 991px) {
+  .projects-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 992px) {
+  .projects-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -196,7 +196,7 @@ export default function Resume() {
         const r         = el.getBoundingClientRect();
         const c         = r.top + r.height / 2;
         const dist      = Math.abs(c - mid);
-        const ratio     = Math.max(0, 1 - dist / (mid + r.height));
+        const ratio     = Math.max(0, 1 - dist / mid);
         const scale     = 0.8 + ratio * 0.4;
         el.style.transform = `translateY(-50%) scale(${scale})`;
         const dynamic  = base + (cardWidth * (1 - scale)) / 2;


### PR DESCRIPTION
## Summary
- reduce zoom ratio denominator for smoother scaling
- limit projects page to max three columns via CSS grid media queries

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0e9281ec832ba47af7208343d46d