### PR TITLE
Fix resume timeline zoom effect

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -191,14 +191,15 @@ export default function Resume() {
     const fn = () => {
       const mid = window.innerHeight / 2;
       items.forEach((el) => {
+        const card      = el.querySelector(".card");
         const connector = el.querySelector(".connector");
         const base      = parseFloat(el.dataset.baseconnector);
         const r         = el.getBoundingClientRect();
         const c         = r.top + r.height / 2;
         const dist      = Math.abs(c - mid);
-        const ratio     = Math.max(0, 1 - dist / mid);
+        const ratio     = Math.max(0, 1 - dist / (mid + r.height));
         const scale     = 0.8 + ratio * 0.4;
-        el.style.transform = `translateY(-50%) scale(${scale})`;
+        card.style.transform = `scale(${scale})`;
         const dynamic  = base + (cardWidth * (1 - scale)) / 2;
         const factor   = dynamic / base;
         connector.style.transform = `translateY(-50%) scaleX(${factor})`;


### PR DESCRIPTION
## Summary
- restore logic for zooming resume timeline cards on scroll

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a13b7371c832b941372975af09b13