### PR TITLE
Fix resume scroll zoom

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -465,7 +465,7 @@ html,body{
 .timeline {
   position: relative;
   margin-top: 0;
-  height: 180vh;      /* adjust scroll length */
+  height: 300vh;      /* adjust scroll length */
   width: 100%;
   background: #e9ecef;
   overflow-x: hidden;
@@ -551,6 +551,9 @@ html,body{
   padding: 1rem;
   width: 280px;
   box-sizing: border-box;
+  transform-origin: center;
+  transition: transform .2s ease-out;
+  transform: scale(0.8);
 }
 .exp-logo {
   display: block;           /* make img a block so auto margins work */

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useEffect, useState } from "react";
+import React, { useMemo, useState, useLayoutEffect } from "react";
 import "../../App.css";
 import ExperienceModal from "./ExperienceModal";
 import placeholderLogo from "../../low_contrast_linen.png";
@@ -185,7 +185,7 @@ export default function Resume() {
   }, [minT, maxT]);
 
   // 5) Magnify cards on scroll and adjust connector lengths
-  useEffect(() => {
+  useLayoutEffect(() => {
     const items = document.querySelectorAll(".timeline-item");
     const cardWidth = 280;
     const fn = () => {
@@ -197,7 +197,7 @@ export default function Resume() {
         const r         = el.getBoundingClientRect();
         const c         = r.top + r.height / 2;
         const dist      = Math.abs(c - mid);
-        const ratio     = Math.max(0, 1 - dist / (mid + r.height));
+        const ratio     = Math.max(0, 1 - dist / mid);
         const scale     = 0.8 + ratio * 0.4;
         card.style.transform = `scale(${scale})`;
         const dynamic  = base + (cardWidth * (1 - scale)) / 2;


### PR DESCRIPTION
## Summary
- ensure resume cards scale with scroll
- increase timeline height for noticeable scrolling
- set card transform properties and measure scale in layout effect

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a15f29c2c832b85e26384fcf5e2e6