### PR TITLE
Fix resume card scaling on scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -551,6 +551,9 @@ html,body{
   padding: 1rem;
   width: 280px;
   box-sizing: border-box;
+  transform-origin: center;
+  transition: transform .2s ease-out;
+  transform: scale(0.8);
 }
 .exp-logo {
   display: block;           /* make img a block so auto margins work */

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useEffect, useState } from "react";
+import React, { useMemo, useState, useLayoutEffect } from "react";
 import "../../App.css";
 import ExperienceModal from "./ExperienceModal";
 import placeholderLogo from "../../low_contrast_linen.png";
@@ -185,9 +185,10 @@ export default function Resume() {
   }, [minT, maxT]);
 
   // 5) Magnify cards on scroll and adjust connector lengths
-  useEffect(() => {
+  useLayoutEffect(() => {
     const items = document.querySelectorAll(".timeline-item");
     const cardWidth = 280;
+
     const fn = () => {
       const mid = window.innerHeight / 2;
       items.forEach((el) => {
@@ -197,7 +198,7 @@ export default function Resume() {
         const r         = el.getBoundingClientRect();
         const c         = r.top + r.height / 2;
         const dist      = Math.abs(c - mid);
-        const ratio     = Math.max(0, 1 - dist / (mid + r.height));
+        const ratio     = Math.max(0, 1 - dist / mid);
         const scale     = 0.8 + ratio * 0.4;
         card.style.transform = `scale(${scale})`;
         const dynamic  = base + (cardWidth * (1 - scale)) / 2;
@@ -205,12 +206,15 @@ export default function Resume() {
         connector.style.transform = `translateY(-50%) scaleX(${factor})`;
       });
     };
+
+    const handle = () => requestAnimationFrame(fn);
+
     fn();
-    window.addEventListener("scroll", fn, { passive: true });
-    window.addEventListener("resize", fn);
+    window.addEventListener("scroll", handle, { passive: true });
+    window.addEventListener("resize", handle);
     return () => {
-      window.removeEventListener("scroll", fn);
-      window.removeEventListener("resize", fn);
+      window.removeEventListener("scroll", handle);
+      window.removeEventListener("resize", handle);
     };
   }, [sorted]);
 


### PR DESCRIPTION
## Summary
- use `useLayoutEffect` to capture scroll position before paint
- throttle updates with `requestAnimationFrame`
- give timeline cards a default reduced scale and transition for smoother resizing

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a175d4928832bb012b996ab73fa16