### PR TITLE
Fix resume scroll scaling

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -236,7 +236,10 @@ export default function Resume() {
           Education
         </span>
       </div>
-      <div className={`timeline ${fading ? "fading" : ""}`}>
+      <div
+        className={`timeline ${fading ? "fading" : ""}`}
+        style={{ height: `${(sorted.length + 1) * 100}vh` }}
+      >
       {/* Spine */}
       <div className="spine" />
 


### PR DESCRIPTION
## Summary
- make timeline height scale with experience count

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a18ef701c832bb95b02ef8bb01634