### PR TITLE
Fix resume card scaling on scroll

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -211,10 +211,11 @@ export default function Resume() {
     const handle = () => requestAnimationFrame(update);
 
     update();
-    window.addEventListener("scroll", handle, { passive: true });
+    const target = document.scrollingElement || document.documentElement;
+    target.addEventListener("scroll", handle, { passive: true });
     window.addEventListener("resize", handle);
     return () => {
-      window.removeEventListener("scroll", handle);
+      target.removeEventListener("scroll", handle);
       window.removeEventListener("resize", handle);
     };
   }, [sorted]);


### PR DESCRIPTION
## Summary
- bind scroll listener to the actual scrolling element for timeline updates

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1d392664832b9436675c3f9285b3