### PR TITLE
Fix resume scroll effect

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -211,7 +211,7 @@ export default function Resume() {
     const handle = () => requestAnimationFrame(update);
 
     update();
-    const target = document.scrollingElement || document.documentElement;
+    const target = window;
     target.addEventListener("scroll", handle, { passive: true });
     window.addEventListener("resize", handle);
     return () => {


### PR DESCRIPTION
## Summary
- ensure scroll handler attaches to `window` so experience cards resize during scrolling

## Testing
- `npm test --silent --progress=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1e5f9f44832b95474f1f91c15d97