### PR TITLE
Improve mobile margins on experience cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -626,7 +626,8 @@ html,body{
   }
 
   .timeline-item .card {
-    width: 100%;
+    width: calc(100% - 2rem);
+    margin: 0 1rem;
     padding: 0.25rem 0.5rem;
     font-size: clamp(0.65rem, 3vw, 0.9rem);
     max-height: 8rem;


### PR DESCRIPTION
## Summary
- adjust CSS so experience cards have left/right margins in mobile layout

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4492ad28832bba524f18806d39cb