### PR TITLE
Fix resume view toggle buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -779,12 +779,15 @@ html,body{
   z-index: 1000;
 }
 
-.resume-toggle span {
+.resume-toggle button {
   cursor: pointer;
   font-weight: bold;
+  background: none;
+  border: none;
+  padding: 0;
 }
 
-.resume-toggle span.active {
+.resume-toggle button.active {
   text-decoration: underline;
 }
 .project-thumb {

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -224,19 +224,21 @@ export default function Resume() {
     <>
     <div className="timeline-wrapper">
       <div className="resume-toggle">
-        <span
+        <button
+          type="button"
           className={view === "career" ? "active" : ""}
           onClick={() => handleToggle("career")}
         >
           Career
-        </span>
+        </button>
         <span> | </span>
-        <span
+        <button
+          type="button"
           className={view === "education" ? "active" : ""}
           onClick={() => handleToggle("education")}
         >
           Education
-        </span>
+        </button>
       </div>
       <div className={`timeline ${fading ? "fading" : ""}`}>
       {/* Spine */}


### PR DESCRIPTION
## Summary
- use `<button>` elements for career/education toggle
- adjust styling for new buttons

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a63694df0832b866aedb69c260a5e