### PR TITLE
Move resume toggle to upper left

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -770,11 +770,10 @@ html,body{
 /* Toggle buttons on Resume page */
 .resume-toggle {
   text-align: center;
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-bottom: 20px; /* roughly 20px gap above the timeline */
+  position: fixed;
+  top: 5rem; /* space below navigation */
+  left: 1rem;
+  transform: none;
   font-family: 'Montserrat', sans-serif;
   z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- reposition `Career/Education` buttons on the resume page

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6b5abee0832baaed22f78cdc759e