### PR TITLE
Add scroll hide behavior for resume buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -779,9 +779,15 @@ html,body{
   position: absolute;
   top: 0;
   right: 0;
+  margin-right: 1rem;
   transform: none;
+  transition: transform 0.3s ease-in-out;
   font-family: 'Montserrat', sans-serif;
   z-index: 1000;
+}
+
+.resume-toggle.slide-out {
+  transform: translateX(120%);
 }
 
 .resume-toggle button {

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState, useLayoutEffect } from "react";
+import React, { useMemo, useState, useLayoutEffect, useEffect } from "react";
 import "../../App.css";
 import ExperienceModal from "./ExperienceModal";
 import placeholderLogo from "../../low_contrast_linen.png";
@@ -135,6 +135,15 @@ export default function Resume() {
   const [selected, setSelected] = useState(null);
   const [view, setView] = useState("career");
   const [fading, setFading] = useState(false);
+  const [atTop, setAtTop] = useState(true);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setAtTop(window.scrollY < 50);
+    };
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
 
   const handleToggle = (newView) => {
     if (newView === view) return;
@@ -223,7 +232,7 @@ export default function Resume() {
   return (
     <>
     <div className="timeline-wrapper">
-      <div className="resume-toggle">
+      <div className={`resume-toggle ${atTop ? "" : "slide-out"}`}>
         <button
           type="button"
           className={view === "career" ? "active" : ""}


### PR DESCRIPTION
## Summary
- space toggle buttons away from right edge
- slide toggle buttons off screen when scrolling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a71291840832ba41ec631f24e4d85