### PR TITLE
Extend hero background without moving content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -68,13 +68,28 @@ html,body{
   background-position: top center;
   background-repeat: no-repeat;
   background-attachment: scroll;
-  /* Extend the hero background across two screen heights */
-  min-height: 200vh;
+  /* Keep original layout */
+  min-height: 100vh;
   position: relative;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+}
+
+/* Extend the background behind the next section without shifting content */
+.backgroundImg::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  height: 100vh;
+  background-image: url('../public/loganbackgroundwpaint2.png');
+  background-size: cover;
+  background-position: top center;
+  background-repeat: no-repeat;
+  z-index: -1;
 }
 
 .introHeader {
@@ -893,6 +908,7 @@ html,body{
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
+  background-color: #f5f5f5;
 }
 
 /* Responsive sizing for hero name */


### PR DESCRIPTION
## Summary
- keep hero `.backgroundImg` height at `100vh`
- extend its background image using a pseudo-element so layout is unchanged
- set a new light colour for `.homeContent` so the second page has a different background

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb23a67a8832bb58d2625d1f7b26c