### PR TITLE
Fix hero background visibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -908,7 +908,7 @@ html,body{
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  background-color: #f5f5f5;
+  background-color: transparent;
 }
 
 /* Responsive sizing for hero name */


### PR DESCRIPTION
## Summary
- keep the extended hero background visible
- make the home content transparent so the background shows through

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb448aa74832bb2c0b5f4f82a2637