### PR TITLE
Fix hero image display on homepage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,9 @@ html,body{
 .jumboSpacing {
   padding-top: 0;
   padding-bottom: 0;
+  /* Override Bootstrap jumbotron background so extended hero image is visible */
+  background-color: transparent;
+  position: relative;
 }
 .backgroundImg {
   background-image: url('../public/loganbackgroundwpaint2.png');


### PR DESCRIPTION
## Summary
- ensure jumbotron uses a transparent background

## Testing
- `npm test --silent --unsafe-perm` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb4fc8624832ba414623d8e0aba56