### PR TITLE
Move rotating skills to hero section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -855,7 +855,7 @@ html,body{
 /* Rotating skill text on home page */
 .skill-flash-container {
   position: absolute;
-  bottom: 20%;
+  bottom: 10%;
   right: 10%;
   display: flex;
   flex-direction: column;

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -45,10 +45,10 @@ class Home extends Component{
                 <p className="firstName">Logan</p>
                 <p className="lastName">Moss</p>
               </div>
-            </div>
-            <div className="skill-flash-container">
-              <div className="skill-flash-text">{currentSkill}</div>
-              <a href="#bg-bottom" className="see-more-link">See more</a>
+              <div className="skill-flash-container">
+                <div className="skill-flash-text">{currentSkill}</div>
+                <a href="#bg-bottom" className="see-more-link">See more</a>
+              </div>
             </div>
             <a id="bg-bottom"></a>
           </div>


### PR DESCRIPTION
## Summary
- place rotating skills overlay inside the hero section so it appears on the first page
- adjust positioning so text shows near the bottom right of the hero

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbc902b6c832b9608478902cb2a93