### PR TITLE
Restore scroll snap behavior

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -50,9 +50,9 @@ class Home extends Component{
                 <a href="#bg-bottom" className="see-more-link">See more</a>
               </div>
             </div>
-            <a id="bg-bottom">Test for scroll feature</a>
           </div>
-          
+          <div id="bg-bottom" className="homeContent snap-section"></div>
+
         </div>
     );
   } 


### PR DESCRIPTION
## Summary
- update Home.js to add a second `snap-section` containing the `bg-bottom` anchor

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbd860078832b95b4e8577dfaa4bb