### PR TITLE
Adjust hero scroll snap to slide within 2‑screen background

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -39,8 +39,8 @@ class Home extends Component{
     const currentSkill = rotatingSkills[currentSkillIndex];
     return (
         <div className="jumbotron jumbotron-fluid jumboSpacing">
-          <div className="backgroundImg snap-section">
-            <div className="introHeader">
+          <div className="backgroundImg">
+            <div className="introHeader snap-section">
               <div className="centerTextDiv">
                 <p className="firstName">Logan</p>
                 <p className="lastName">Moss</p>
@@ -50,8 +50,8 @@ class Home extends Component{
                 <a href="#bg-bottom" className="see-more-link">See more</a>
               </div>
             </div>
+            <div id="bg-bottom" className="homeContent snap-section"></div>
           </div>
-          <div id="bg-bottom" className="homeContent snap-section"></div>
 
         </div>
     );


### PR DESCRIPTION
## Summary
- allow hero to snap between its top and bottom halves
- keep extended background at 200vh

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbea45900832bbe406b0fbb89b75c