### PR TITLE
Add nav link background style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -191,17 +191,19 @@ html,body{
   color: black;
   font-family: 'Raleway', sans-serif;
   margin-right: 4%;
-  /* padding-top: 6px; */
   font-weight: bold;
-
+  display: block;
+  background-color: rgba(0, 0, 0, 0.5);
+  padding: 0.5rem 0.75rem;
+  transition: transform 0.3s;
 }
 .customNavLink:hover{
   animation-name: flash;
   animation-iteration-count: infinite;
   text-decoration: none;
-  /* color: white; */
   animation-duration: 2.5s;
   animation-direction: alternate;
+  transform: translateX(-10px);
 }
 .active {
   border-bottom: black 1px solid;


### PR DESCRIPTION
## Summary
- add translucent black background to nav links
- animate nav links to shift slightly left on hover

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc1e14900832b8d09a0df47355f0f