### PR TITLE
Fix nav hover gap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -195,7 +195,7 @@ html,body{
   display: block;
   background-color: black;
   padding: 0.25rem 0.75rem;
-  transition: transform 0.3s;
+  transition: transform 0.3s, margin-right 0.3s;
 }
 .customNavLink:hover{
   animation-name: flash;
@@ -204,6 +204,7 @@ html,body{
   animation-duration: 2.5s;
   animation-direction: alternate;
   transform: translateX(-10px);
+  margin-right: -10px;
 }
 .active {
   border-bottom: black 1px solid;


### PR DESCRIPTION
## Summary
- keep nav links anchored to the right when sliding left on hover

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccc9dd1d0832b87fa8d53cfc74007