### PR TITLE
Ensure nav routes start at page top

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Contact from "./components/Contact/Contact"
 import Projects from "./components/Projects/Projects"
 import Resume from "./components/Resume/Resume"
 import FloatingLinks from "./components/FloatingLinks"
+import ScrollToTop from "./utils/ScrollToTop";
 import {
   BrowserRouter as Router,
   Switch,
@@ -17,6 +18,7 @@ class App extends Component {
   render(){
     return (
       <Router basename={process.env.PUBLIC_URL}>
+        <ScrollToTop />
         <Nav />
         <div className="App">
           <Switch>

--- a/src/utils/ScrollToTop.js
+++ b/src/utils/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollToTop({ location }) {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+
+  return null;
+}
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
## Summary
- add ScrollToTop helper that resets scroll position on navigation
- use ScrollToTop in App router

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cce76d2d4832ba92b8c0572c7da38