### PR TITLE
Fix navigation scroll snap regression

### DIFF
--- a/src/utils/ScrollToTop.js
+++ b/src/utils/ScrollToTop.js
@@ -3,8 +3,10 @@ import { withRouter } from 'react-router-dom';
 
 function ScrollToTop({ location }) {
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [location]);
+    if (!location.hash) {
+      window.scrollTo(0, 0);
+    }
+  }, [location.pathname]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- adjust scroll-to-top behavior to avoid resetting position when following in-page links

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccf815c60832b93a16d815ae70562