### PR TITLE
Fix home scroll snapping

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -51,7 +51,6 @@ body {
 html,body{
   height:100%;
   background-color: #e9ecef;
-  scroll-snap-type: y mandatory;
   scroll-behavior: smooth;
   overflow-y: scroll;
 }
@@ -74,6 +73,7 @@ html,body{
   /* Keep original layout */
   min-height: 200vh;
   position: relative;
+  scroll-snap-type: y mandatory;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;


### PR DESCRIPTION
## Summary
- apply scroll snap on `.backgroundImg` so only the homepage uses snapping

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd1724a54832b89b64bbba04c66cf