### PR TITLE
Improve anchor scroll handling

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -29,26 +29,6 @@ class Home extends Component{
         currentSkillIndex: (prev.currentSkillIndex + 1) % shuffled.length
       }));
     }, 3000);
-
-    if (this.props.location && this.props.location.hash === '#bg-bottom') {
-      const el = document.getElementById('bg-bottom');
-      if (el) {
-        el.scrollIntoView({ behavior: 'smooth' });
-      }
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-      this.props.location &&
-      this.props.location.hash !== prevProps.location.hash &&
-      this.props.location.hash === '#bg-bottom'
-    ) {
-      const el = document.getElementById('bg-bottom');
-      if (el) {
-        el.scrollIntoView({ behavior: 'smooth' });
-      }
-    }
   }
 
   componentWillUnmount() {

--- a/src/utils/ScrollToTop.js
+++ b/src/utils/ScrollToTop.js
@@ -3,10 +3,15 @@ import { withRouter } from 'react-router-dom';
 
 function ScrollToTop({ location }) {
   useEffect(() => {
-    if (!location.hash) {
+    if (location.hash) {
+      const el = document.getElementById(location.hash.slice(1));
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else {
       window.scrollTo(0, 0);
     }
-  }, [location.pathname]);
+  }, [location.pathname, location.hash]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- use a global ScrollToTop component that also handles hash anchors
- remove redundant hash scrolling logic in `Home`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd342db44832b900ab077aec8f662