### PR TITLE
Fix scroll snap issue

### DIFF
--- a/src/utils/ScrollToTop.js
+++ b/src/utils/ScrollToTop.js
@@ -9,7 +9,10 @@ function ScrollToTop({ location }) {
         el.scrollIntoView({ behavior: 'smooth' });
       }
     } else {
-      window.scrollTo(0, 0);
+      // Jump instantly to the top when navigating between pages so the user
+      // can immediately scroll. Explicitly set behavior to 'auto' to override
+      // the global CSS smooth scroll setting.
+      window.scrollTo({ top: 0, behavior: 'auto' });
     }
   }, [location.pathname, location.hash]);
 


### PR DESCRIPTION
## Summary
- ensure page scroll resets instantly on navigation so user can scroll immediately

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd66ace14832b9a6b59441f4ba51a