### PR TITLE
Restore snap scrolling and remove Home link

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,7 @@ html,body{
   */
   scroll-behavior: auto;
   overflow-y: scroll;
+  scroll-snap-type: y mandatory;
 }
 
 /* BootStrap */

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -54,19 +54,6 @@ function Nav() {
             Projects
           </li>
         </Link>
-        <Link
-          to={{ pathname: "/", hash: "#bg-bottom" }}
-          className="customNavLink"
-          onClick={closeMenu}
-          style={{ color: location.pathname === "/" ? "#00f0ed" : "white" }}
-        >
-          <li
-            className="customNavLink"
-            style={{ color: location.pathname === "/" ? "#00f0ed" : "white" }}
-          >
-            Home
-          </li>
-        </Link>
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary
- enable CSS scroll snapping on `html, body`
- remove Home navigation link from navbar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd99c9f4c832bafe278cf4a6c7aa7