### PR TITLE
Fix skill overlay location and adjust snap scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -79,7 +79,6 @@ html,body{
   /* Keep original layout */
   min-height: 200vh;
   position: relative;
-  scroll-snap-type: y mandatory;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -868,7 +867,7 @@ html,body{
 /* Rotating skill text on home page */
 .skill-flash-container {
   position: absolute;
-  bottom: 20%;
+  bottom: 10%;
   right: 10%;
   display: flex;
   flex-direction: column;

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -41,7 +41,10 @@ class Home extends Component{
 
   render(){
     const { rotatingSkills, currentSkillIndex } = this.state;
-    const currentSkill = rotatingSkills[currentSkillIndex];
+    const currentSkill =
+      rotatingSkills.length > 0
+        ? rotatingSkills[currentSkillIndex]
+        : rotatingSkillList[0];
     return (
         <div className="jumbotron jumbotron-fluid jumboSpacing">
           <div className="backgroundImg">
@@ -50,10 +53,10 @@ class Home extends Component{
                 <p className="firstName">Logan</p>
                 <p className="lastName">Moss</p>
               </div>
-            </div>
-            <div className="skill-flash-container">
-              <div className="skill-flash-text">{currentSkill}</div>
-              <a href="#bg-bottom" className="see-more-link">See more</a>
+              <div className="skill-flash-container">
+                <div className="skill-flash-text">{currentSkill}</div>
+                <a href="#bg-bottom" className="see-more-link">See more</a>
+              </div>
             </div>
             <div id="bg-bottom" className="homeContent snap-section"></div>
           </div>


### PR DESCRIPTION
## Summary
- place rotating skill list back inside the hero section
- default first skill to avoid undefined text
- move skill overlay slightly higher and rely on global scroll snap

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cda76e4f0832b82f4c83124390b1c