### PR TITLE
Fix nav link slide effect

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -200,8 +200,7 @@ html,body{
   display: block;
   background-color: black;
   padding: 0.25rem 0.75rem;
-  transition: transform 0.3s, margin-right 0.3s;
-  margin-right: 0;
+  transition: transform 0.3s;
 }
 .customNavLink:hover {
   animation-name: flash;
@@ -211,7 +210,6 @@ html,body{
   animation-direction: alternate;
   transform-origin: right;
   transform: translateX(-8px);
-  margin-right: -8px;
 }
 .active {
   border-bottom: black 1px solid;


### PR DESCRIPTION
## Summary
- adjust nav link hover styles so they slide left via `transform`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdcc2ca44832ba78614832378d332