### PR TITLE
Fix nav hover gap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -208,6 +208,7 @@ html,body{
   text-decoration: none;
   animation-duration: 2.5s;
   animation-direction: alternate;
+  margin-right: -8px;
   transform-origin: right;
   transform: translateX(-8px);
 }


### PR DESCRIPTION
## Summary
- keep navbar links flush to the right edge when hovered

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cde2690a4832b99b978e97f254d4e