### PR TITLE
Fix nav link hover transition

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -208,10 +208,16 @@ html,body{
   text-decoration: none;
   animation-duration: 2.5s;
   animation-direction: alternate;
-  transform-origin: right;
-  transform: translateX(-8px);
-  margin-right: -8px;
   padding-left: 1.25rem;
+}
+
+/* Slide the text itself so the right edge stays fixed */
+.customNavLink li {
+  transition: transform 0.3s;
+}
+
+.customNavLink:hover li {
+  transform: translateX(-8px);
 }
 .active {
   border-bottom: black 1px solid;


### PR DESCRIPTION
## Summary
- stop shifting nav links right edge on hover
- slide link text left while maintaining right edge connection

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850501f4f38832badd500f8160a15e1