### PR TITLE
Fix infinite scroll for projects

### DIFF
--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import "../../App.css";
 import projects from './projects.json';
 import "animate.css/animate.min.css";
@@ -7,12 +7,25 @@ import ProjectModal from './ProjectModal';
 
 export default function Projects() {
   const [selected, setSelected] = useState(null);
+  const [visibleCount, setVisibleCount] = useState(6);
+  const loadMoreRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        setVisibleCount(prev => Math.min(prev + 3, projects.length));
+      }
+    });
+    const refCurrent = loadMoreRef.current;
+    if (refCurrent) observer.observe(refCurrent);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <>
     <div className="projects-container">
       <div className="projects-grid projectRow">
-        {projects.map(project => (
+        {projects.slice(0, visibleCount).map(project => (
           <div key={project.id} className="cardCSS">
             <ScrollAnimation delay={300} animateIn="fadeIn">
               <img
@@ -26,6 +39,9 @@ export default function Projects() {
             </ScrollAnimation>
           </div>
         ))}
+        {visibleCount < projects.length && (
+          <div ref={loadMoreRef} style={{ height: '1px' }} />
+        )}
       </div>
     </div>
     <ProjectModal project={selected} onClose={() => setSelected(null)} />


### PR DESCRIPTION
## Summary
- enable intersection observer based infinite scrolling for Projects page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850646b770c832b95ffe8f4e975d4eb