### PR TITLE
Fix intersection observer to enable continuous project loading

### DIFF
--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -18,8 +18,11 @@ export default function Projects() {
     });
     const refCurrent = loadMoreRef.current;
     if (refCurrent) observer.observe(refCurrent);
-    return () => observer.disconnect();
-  }, []);
+    return () => {
+      if (refCurrent) observer.unobserve(refCurrent);
+      observer.disconnect();
+    };
+  }, [visibleCount]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- ensure IntersectionObserver re-attaches after each update so scrolling loads more projects

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506567c474832b9336fd081b035e5f