### PR TITLE
Fix projects page scroll and loading

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,7 +58,10 @@ html,body{
   */
   scroll-behavior: auto;
   overflow-y: scroll;
-  scroll-snap-type: y mandatory;
+  /* Disable snap scrolling site-wide so pages like Projects can scroll
+     normally. Snap alignment is still applied to individual sections
+     via the .snap-section class. */
+  /* scroll-snap-type: y mandatory; */
 }
 
 /* BootStrap */

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -18,6 +18,8 @@ export default function Projects({ projects = projectsData }) {
       }
     };
     window.addEventListener('scroll', handleScroll);
+    // Trigger once on mount in case the initial items don't fill the viewport
+    handleScroll();
     return () => window.removeEventListener('scroll', handleScroll);
   }, [projects.length]);
 


### PR DESCRIPTION
## Summary
- adjust Projects page infinite scroll to trigger once on mount
- disable global scroll snap so pages scroll normally

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685069780118832b824dc8683b8f2ffe