### PR TITLE
Fix project card visibility on scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -333,6 +333,14 @@ html,body{
 
 .cardCSS {
   padding: 15px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.cardCSS.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .projectCard {

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -1,12 +1,29 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import "../../App.css";
 import projects from './projects.json';
-import "animate.css/animate.min.css";
-import ScrollAnimation from 'react-animate-on-scroll';
 import ProjectModal from './ProjectModal';
 
 export default function Projects() {
   const [selected, setSelected] = useState(null);
+
+  // Reveal project cards when they enter the viewport
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+
+    const cards = document.querySelectorAll('.cardCSS');
+    cards.forEach(card => observer.observe(card));
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <>
@@ -14,16 +31,14 @@ export default function Projects() {
       <div className="projects-grid projectRow">
         {projects.map(project => (
           <div key={project.id} className="cardCSS">
-            <ScrollAnimation delay={300} animateIn="fadeIn">
-              <img
-                src={project.image}
-                alt={project.alt}
-                className="project-thumb paused"
-                onClick={() => setSelected(project)}
-                onMouseEnter={e => e.currentTarget.classList.remove('paused')}
-                onMouseLeave={e => e.currentTarget.classList.add('paused')}
-              />
-            </ScrollAnimation>
+            <img
+              src={project.image}
+              alt={project.alt}
+              className="project-thumb paused"
+              onClick={() => setSelected(project)}
+              onMouseEnter={e => e.currentTarget.classList.remove('paused')}
+              onMouseLeave={e => e.currentTarget.classList.add('paused')}
+            />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- trigger project card visibility with IntersectionObserver
- add fade-in styles for project cards

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506cdc851c832ba19281fd9d481eda