### PR TITLE
Improve about section layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -231,6 +231,32 @@ html,body{
 
 .aboutMeDiv {
   margin-top: 4%;
+  height: 100%;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: repeat(5, 1fr);
+  gap: 1rem;
+}
+
+.about-description {
+  grid-column: 1 / 2;
+  grid-row: 1 / 3;
+  align-self: start;
+  padding: 1rem;
+}
+
+.skills-section {
+  grid-column: 2 / 3;
+  grid-row: 1 / 6;
+  padding: 1rem;
+}
+
+.contact-section {
+  grid-column: 1 / 2;
+  grid-row: 3 / 4;
+  align-self: end;
+  padding: 1rem;
 }
 
 .mobileMenuButton {

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -60,7 +60,29 @@ class Home extends Component{
             </div>
             <div id="bg-bottom" className="homeContent snap-section">
               <div className="jumbotron aboutMeDiv">
-
+                <div className="about-description">
+                  <h2>About Me</h2>
+                  <p>
+                    I am a developer with a passion for learning new
+                    technologies and building useful applications.
+                  </p>
+                </div>
+                <div className="skills-section">
+                  <h2>Skills</h2>
+                  <ul>
+                    {rotatingSkillList.map(skill => (
+                      <li key={skill}>{skill}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="contact-section">
+                  <h2>Contact</h2>
+                  <p>
+                    Email:
+                    {' '}
+                    <a href="mailto:lrdjmoss@gmail.com">lrdjmoss@gmail.com</a>
+                  </p>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- fill the bottom of the homepage with the about section
- add placeholder content and skills/contact areas
- style the about section using CSS grid

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507524dbc4832b809dc377406b1297