### PR TITLE
Switch home page layout to flexbox

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -232,38 +232,29 @@ html,body{
 .aboutMeDiv {
   margin: 6%;
   margin-bottom: -4%;
-
   width: 80%;
-  display: grid;
-  grid-template-columns: 8fr 1fr;
-  grid-template-rows: repeat(4, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 2rem;
   background: transparent;
 }
 
 .about-description {
   background-color: rgba(0, 0, 0, 0.4);
-  grid-column: 1 / 2;
-  grid-row: 1 / 3;
-  align-self: start;
   padding: 1rem;
+  flex: 3 1 60%;
 }
 
 .skills-section {
   background-color: rgba(0, 0, 0, 0.4);
-  grid-column: 2 / 3;
-  grid-row: 1 / 6;
   padding: 1rem;
   color: white;
+  flex: 1 1 30%;
 }
 
-.contact-section {
-  background-color: rgba(0, 0, 0, 0.4);
-  color: white;
-  grid-column: 1 / 2;
-  grid-row: 4 / 4;
-  align-self: end;
-  padding: 1rem;
+.contact-link {
+  margin-top: 2rem;
+  font-size: 1rem;
 }
 
 .mobileMenuButton {

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -75,14 +75,9 @@ class Home extends Component{
                     ))}
                   </ul>
                 </div>
-                <div className="contact-section">
-                  <h2>Contact</h2>
-                  <p>
-                    Email:
-                    {' '}
-                    <a href="mailto:lrdjmoss@gmail.com">lrdjmoss@gmail.com</a>
-                  </p>
-                </div>
+              </div>
+              <div className="contact-link">
+                Email: <a href="mailto:lrdjmoss@gmail.com">lrdjmoss@gmail.com</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- convert the About section on the home page from CSS grid to flexbox
- move the contact info out of the flex layout and display it as a link at the bottom

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507b49a3a0832badd27987c784440f