### PR TITLE
Improve home page layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -235,7 +235,8 @@ html,body{
   width: 80%;
   display: flex;
   flex-wrap: wrap;
-  gap: 2rem;
+  gap: 4rem; /* increased spacing between About and Skills sections */
+  align-items: stretch; /* allow children to span full height */
   background: transparent;
 }
 
@@ -250,10 +251,14 @@ html,body{
   padding: 1rem;
   color: white;
   flex: 1 1 30%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between; /* stretch content vertically */
 }
 
 .contact-link {
-  margin-top: 2rem;
+  margin-top: auto; /* push link to bottom of page */
   font-size: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- increase the gap between About Me and Skills
- stretch Skills section to fill About Me height
- move contact link to the bottom of the page

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507dd89ab0832ba6e0853e667b8a4a