### PR TITLE
Add Wordle gate overlay

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -963,3 +963,69 @@ html,body{
     font-size: clamp(2.5rem, 15vw, 4rem);
   }
 }
+
+/* Wordle gate styles */
+.wordle-gate-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.95);
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  gap: 1rem;
+}
+
+.wordle-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.wordle-row {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.wordle-cell {
+  width: 3rem;
+  height: 3rem;
+  border: 2px solid #555;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  text-transform: uppercase;
+}
+
+.wordle-cell.correct {
+  background: #6aaa64;
+  border-color: #6aaa64;
+}
+
+.wordle-cell.present {
+  background: #c9b458;
+  border-color: #c9b458;
+}
+
+.wordle-cell.absent {
+  background: #787c7e;
+  border-color: #787c7e;
+}
+
+.wordle-form input {
+  width: 15rem;
+  padding: 0.5rem;
+  font-size: 1.5rem;
+  text-align: center;
+  letter-spacing: 0.3rem;
+  text-transform: uppercase;
+  border: 2px solid white;
+  background: transparent;
+  color: white;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Contact from "./components/Contact/Contact"
 import Projects from "./components/Projects/Projects"
 import Resume from "./components/Resume/Resume"
 import FloatingLinks from "./components/FloatingLinks"
+import WordleGate from "./components/WordleGate";
 import ScrollToTop from "./utils/ScrollToTop";
 import {
   BrowserRouter as Router,
@@ -15,9 +16,17 @@ import {
 
 
 class App extends Component {
+  state = { gateUnlocked: false };
+
+  handleUnlock = () => {
+    this.setState({ gateUnlocked: true });
+  };
+
   render(){
+    const { gateUnlocked } = this.state;
     return (
       <Router basename={process.env.PUBLIC_URL}>
+        {!gateUnlocked && <WordleGate onUnlock={this.handleUnlock} />}
         <ScrollToTop />
         <Nav />
         <div className="App">

--- a/src/components/WordleGate.js
+++ b/src/components/WordleGate.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import '../App.css';
+
+const SECRET = 'LOGAN';
+
+function evaluateGuess(guess) {
+  const secret = SECRET.split('');
+  const result = Array(5).fill('absent');
+  const remaining = secret.slice();
+
+  // First pass for correct letters
+  for (let i = 0; i < 5; i++) {
+    if (guess[i] === secret[i]) {
+      result[i] = 'correct';
+      remaining[i] = null;
+    }
+  }
+
+  // Second pass for present letters
+  for (let i = 0; i < 5; i++) {
+    if (result[i] === 'correct') continue;
+    const idx = remaining.indexOf(guess[i]);
+    if (idx !== -1) {
+      result[i] = 'present';
+      remaining[idx] = null;
+    }
+  }
+  return result;
+}
+
+function WordleGate({ onUnlock }) {
+  const [guesses, setGuesses] = useState([]); // array of { word, result }
+  const [current, setCurrent] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (current.length !== 5) return;
+    const word = current.toUpperCase();
+    const result = evaluateGuess(word);
+    const nextGuesses = [...guesses, { word, result }];
+    setGuesses(nextGuesses);
+    setCurrent('');
+    if (word === SECRET) {
+      onUnlock();
+    } else if (nextGuesses.length >= 6) {
+      setMessage(`The word was ${SECRET}. Reload to try again.`);
+    }
+  };
+
+  return (
+    <div className="wordle-gate-overlay">
+      <h2>Guess the secret 5-letter word</h2>
+      <div className="wordle-grid">
+        {guesses.map((g, i) => (
+          <div className="wordle-row" key={i}>
+            {g.word.split('').map((ch, idx) => (
+              <span key={idx} className={`wordle-cell ${g.result[idx]}`}>{ch}</span>
+            ))}
+          </div>
+        ))}
+        {guesses.length < 6 && (
+          <form onSubmit={handleSubmit} className="wordle-form">
+            <input
+              type="text"
+              value={current}
+              maxLength={5}
+              autoFocus
+              onChange={(e) => setCurrent(e.target.value.toUpperCase())}
+            />
+          </form>
+        )}
+      </div>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}
+
+export default WordleGate;


### PR DESCRIPTION
## Summary
- create `WordleGate` component to gate access behind a Wordle-style puzzle
- add overlay styles in `App.css`
- integrate gate with `App` so site only appears after correct word is guessed

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507fd49440832bade624fca0398a0a