### PR TITLE
Add used letter display and fade-out effect

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -979,6 +979,7 @@ html,body{
   justify-content: center;
   color: white;
   gap: 1rem;
+  transition: opacity 0.5s;
 }
 
 .wordle-grid {
@@ -1028,4 +1029,12 @@ html,body{
   border: 2px solid white;
   background: transparent;
   color: white;
+}
+
+.wordle-gate-overlay.fade-out {
+  opacity: 0;
+}
+
+.used-letters {
+  font-size: 1.2rem;
 }

--- a/src/components/WordleGate.js
+++ b/src/components/WordleGate.js
@@ -32,6 +32,8 @@ function WordleGate({ onUnlock }) {
   const [guesses, setGuesses] = useState([]); // array of { word, result }
   const [current, setCurrent] = useState('');
   const [message, setMessage] = useState('');
+  const [usedLetters, setUsedLetters] = useState([]);
+  const [fading, setFading] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -41,15 +43,17 @@ function WordleGate({ onUnlock }) {
     const nextGuesses = [...guesses, { word, result }];
     setGuesses(nextGuesses);
     setCurrent('');
+    setUsedLetters(Array.from(new Set([...usedLetters, ...word.split('')])));
     if (word === SECRET) {
-      onUnlock();
+      setFading(true);
+      setTimeout(() => onUnlock(), 500);
     } else if (nextGuesses.length >= 6) {
       setMessage(`The word was ${SECRET}. Reload to try again.`);
     }
   };
 
   return (
-    <div className="wordle-gate-overlay">
+    <div className={`wordle-gate-overlay${fading ? ' fade-out' : ''}`}>
       <h2>Guess the secret 5-letter word</h2>
       <div className="wordle-grid">
         {guesses.map((g, i) => (
@@ -71,6 +75,9 @@ function WordleGate({ onUnlock }) {
           </form>
         )}
       </div>
+      {usedLetters.length > 0 && (
+        <p className="used-letters">Used letters: {usedLetters.join(' ')}</p>
+      )}
       {message && <p>{message}</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- show used letters after each guess in Wordle gate
- fade out Wordle gate when the word is guessed

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850816568d8832bab183df9e15ba097