### PR TITLE
Adjust Wordle gate fadeout duration

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -979,7 +979,7 @@ html,body{
   justify-content: center;
   color: white;
   gap: 1rem;
-  transition: opacity 0.5s;
+  transition: opacity 1.2s;
 }
 
 .wordle-grid {

--- a/src/components/WordleGate.js
+++ b/src/components/WordleGate.js
@@ -46,7 +46,7 @@ function WordleGate({ onUnlock }) {
     setUsedLetters(Array.from(new Set([...usedLetters, ...word.split('')])));
     if (word === SECRET) {
       setFading(true);
-      setTimeout(() => onUnlock(), 500);
+      setTimeout(() => onUnlock(), 1200);
     } else if (nextGuesses.length >= 6) {
       setMessage(`The word was ${SECRET}. Reload to try again.`);
     }


### PR DESCRIPTION
## Summary
- extend Wordle gate fade-out animation time to 1.2s

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685082233c24832b8e234b5a66a34bd1