### PR TITLE
Add failure animation to Wordle gate

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -979,7 +979,7 @@ html,body{
   justify-content: center;
   color: white;
   gap: 1rem;
-  transition: opacity 1.2s;
+  transition: opacity 2s ease-in-out;
 }
 
 .wordle-grid {
@@ -1033,6 +1033,10 @@ html,body{
 
 .wordle-gate-overlay.fade-out {
   opacity: 0;
+}
+
+.hidden {
+  display: none !important;
 }
 
 .used-letters {

--- a/src/components/WordleGate.js
+++ b/src/components/WordleGate.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import '../App.css';
 
 const SECRET = 'LOGAN';
@@ -34,6 +34,15 @@ function WordleGate({ onUnlock }) {
   const [message, setMessage] = useState('');
   const [usedLetters, setUsedLetters] = useState([]);
   const [fading, setFading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [hideStep, setHideStep] = useState(-1);
+
+  useEffect(() => {
+    if (failed && hideStep < 4) {
+      const id = setTimeout(() => setHideStep(hideStep + 1), 500);
+      return () => clearTimeout(id);
+    }
+  }, [failed, hideStep]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -46,16 +55,22 @@ function WordleGate({ onUnlock }) {
     setUsedLetters(Array.from(new Set([...usedLetters, ...word.split('')])));
     if (word === SECRET) {
       setFading(true);
-      setTimeout(() => onUnlock(), 1200);
+      setTimeout(() => onUnlock(), 2000);
     } else if (nextGuesses.length >= 6) {
-      setMessage(`The word was ${SECRET}. Reload to try again.`);
+      setMessage('Incorrect. Deleting everything...');
+      setFailed(true);
+      setHideStep(0);
     }
   };
 
   return (
-    <div className={`wordle-gate-overlay${fading ? ' fade-out' : ''}`}>
-      <h2>Guess the secret 5-letter word</h2>
-      <div className="wordle-grid">
+    <div
+      className={`wordle-gate-overlay${fading ? ' fade-out' : ''} ${
+        hideStep >= 4 ? 'hidden' : ''
+      }`}
+    >
+      <h2 className={hideStep >= 1 ? 'hidden' : ''}>Guess the secret 5-letter word</h2>
+      <div className={`wordle-grid ${hideStep >= 0 ? 'hidden' : ''}`}>
         {guesses.map((g, i) => (
           <div className="wordle-row" key={i}>
             {g.word.split('').map((ch, idx) => (
@@ -76,9 +91,11 @@ function WordleGate({ onUnlock }) {
         )}
       </div>
       {usedLetters.length > 0 && (
-        <p className="used-letters">Used letters: {usedLetters.join(' ')}</p>
+        <p className={`used-letters ${hideStep >= 2 ? 'hidden' : ''}`}>
+          Used letters: {usedLetters.join(' ')}
+        </p>
       )}
-      {message && <p>{message}</p>}
+      {message && <p className={hideStep >= 3 ? 'hidden' : ''}>{message}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- smooth out Wordle gate fade-out
- hide parts of Wordle gate sequentially when user fails

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850831e706c832ba9ae72443b8c7124