### PR TITLE
Hide site on Wordle fail

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,29 +16,39 @@ import {
 
 
 class App extends Component {
-  state = { gateUnlocked: false };
+  state = { gateUnlocked: false, gateFailed: false };
 
   handleUnlock = () => {
     this.setState({ gateUnlocked: true });
   };
 
+  handleFail = () => {
+    this.setState({ gateFailed: true });
+  };
+
   render(){
-    const { gateUnlocked } = this.state;
+    const { gateUnlocked, gateFailed } = this.state;
     return (
       <Router basename={process.env.PUBLIC_URL}>
-        {!gateUnlocked && <WordleGate onUnlock={this.handleUnlock} />}
-        <ScrollToTop />
-        <Nav />
-        <div className="App">
-          <Switch>
-            {/* <Route path="/portfolio" component={Home}/> */}
-            <Route exact path="/" component={Home}/>
-            <Route path="/resume" component={Resume}/>
-            <Route path="/projects" component={Projects}/>
-            <Route path="/contact" component={Contact}/>
-          </Switch>
-          <FloatingLinks />
-        </div>
+        {!gateUnlocked && (
+          <WordleGate onUnlock={this.handleUnlock} onFail={this.handleFail} />
+        )}
+        {!gateFailed && (
+          <>
+            <ScrollToTop />
+            <Nav />
+            <div className="App">
+              <Switch>
+                {/* <Route path="/portfolio" component={Home}/> */}
+                <Route exact path="/" component={Home} />
+                <Route path="/resume" component={Resume} />
+                <Route path="/projects" component={Projects} />
+                <Route path="/contact" component={Contact} />
+              </Switch>
+              <FloatingLinks />
+            </div>
+          </>
+        )}
       </Router>
     );
   }

--- a/src/components/WordleGate.js
+++ b/src/components/WordleGate.js
@@ -28,7 +28,7 @@ function evaluateGuess(guess) {
   return result;
 }
 
-function WordleGate({ onUnlock }) {
+function WordleGate({ onUnlock, onFail }) {
   const [guesses, setGuesses] = useState([]); // array of { word, result }
   const [current, setCurrent] = useState('');
   const [message, setMessage] = useState('');
@@ -60,6 +60,9 @@ function WordleGate({ onUnlock }) {
       setMessage('Incorrect. Deleting everything...');
       setFailed(true);
       setHideStep(0);
+      if (onFail) {
+        onFail();
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- allow WordleGate to notify of failure
- stop rendering the rest of the site after a failed gate attempt

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508405f0f4832bbaaa7c053818178f