### PR TITLE
Add sequential hiding on Wordle fail

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1035,6 +1035,11 @@ html,body{
   opacity: 0;
 }
 
+.fade-out {
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+ }
+
 .hidden {
   display: none !important;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -16,39 +16,51 @@ import {
 
 
 class App extends Component {
-  state = { gateUnlocked: false, gateFailed: false };
+  state = { gateUnlocked: false, gateFailed: false, hideStep: -1 };
 
   handleUnlock = () => {
     this.setState({ gateUnlocked: true });
   };
 
   handleFail = () => {
-    this.setState({ gateFailed: true });
+    this.setState({ gateFailed: true, hideStep: 0 }, () => {
+      this.hideInterval = setInterval(() => {
+        this.setState(prev => {
+          if (prev.hideStep >= 2) {
+            clearInterval(this.hideInterval);
+            return { hideStep: 3 };
+          }
+          return { hideStep: prev.hideStep + 1 };
+        });
+      }, 500);
+    });
   };
 
+  componentWillUnmount() {
+    clearInterval(this.hideInterval);
+  }
+
   render(){
-    const { gateUnlocked, gateFailed } = this.state;
+    const { gateUnlocked, hideStep } = this.state;
     return (
       <Router basename={process.env.PUBLIC_URL}>
         {!gateUnlocked && (
           <WordleGate onUnlock={this.handleUnlock} onFail={this.handleFail} />
         )}
-        {!gateFailed && (
-          <>
-            <ScrollToTop />
-            <Nav />
-            <div className="App">
-              <Switch>
-                {/* <Route path="/portfolio" component={Home}/> */}
-                <Route exact path="/" component={Home} />
-                <Route path="/resume" component={Resume} />
-                <Route path="/projects" component={Projects} />
-                <Route path="/contact" component={Contact} />
-              </Switch>
-              <FloatingLinks />
-            </div>
-          </>
-        )}
+        <div className={`site-wrapper ${hideStep >= 2 ? 'hidden' : ''}`}>
+          <ScrollToTop />
+          <Nav className={hideStep >= 0 ? 'fade-out' : ''} />
+          <div className={`App ${hideStep >= 1 ? 'fade-out' : ''}`}>
+            <Switch>
+              {/* <Route path="/portfolio" component={Home}/> */}
+              <Route exact path="/" render={() => <Home hideStep={hideStep} />} />
+              <Route path="/resume" component={Resume} />
+              <Route path="/projects" component={Projects} />
+              <Route path="/contact" component={Contact} />
+            </Switch>
+            <FloatingLinks className={hideStep >= 0 ? 'fade-out' : ''} />
+          </div>
+        </div>
       </Router>
     );
   }

--- a/src/components/FloatingLinks.js
+++ b/src/components/FloatingLinks.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import '../App.css';
 
-function FloatingLinks() {
+function FloatingLinks({ className = '' }) {
   return (
-    <div className="floating-links">
+    <div className={`floating-links ${className}`}>
       <a
         href="https://www.linkedin.com/in/loganmoss/"
         target="_blank"

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -41,24 +41,25 @@ class Home extends Component{
 
   render(){
     const { rotatingSkills, currentSkillIndex } = this.state;
+    const { hideStep = -1 } = this.props;
     const currentSkill =
       rotatingSkills.length > 0
         ? rotatingSkills[currentSkillIndex]
         : rotatingSkillList[0];
     return (
         <div className="jumbotron jumbotron-fluid jumboSpacing">
-          <div className="backgroundImg">
+          <div className={`backgroundImg ${hideStep >= 1 ? 'fade-out' : ''}`}>
             <div className="introHeader snap-section">
-              <div className="centerTextDiv">
+              <div className={`centerTextDiv ${hideStep >= 0 ? 'fade-out' : ''}`}>
                 <p className="firstName">Logan</p>
                 <p className="lastName">Moss</p>
               </div>
-              <div className="skill-flash-container">
+              <div className={`skill-flash-container ${hideStep >= 0 ? 'fade-out' : ''}`}>
                 <div className="skill-flash-text">{currentSkill}</div>
                 <a href="#bg-bottom" className="see-more-link">See more</a>
               </div>
             </div>
-            <div id="bg-bottom" className="homeContent snap-section">
+            <div id="bg-bottom" className={`homeContent snap-section ${hideStep >= 0 ? 'fade-out' : ''}`}>
               <div className="jumbotron aboutMeDiv">
                 <div className="about-description">
                   <h2>About Me</h2>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import "../App.css";
 import { Link, useLocation } from 'react-router-dom';
 
-function Nav() {
+function Nav({ className = '' }) {
   const location = useLocation();
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -10,7 +10,7 @@ function Nav() {
   const closeMenu = () => setMenuOpen(false);
 
   return (
-    <nav className="navAnimation customNav">
+    <nav className={`navAnimation customNav ${className}`}>
       <Link
         className="title"
         to="/"

--- a/src/components/WordleGate.js
+++ b/src/components/WordleGate.js
@@ -60,11 +60,14 @@ function WordleGate({ onUnlock, onFail }) {
       setMessage('Incorrect. Deleting everything...');
       setFailed(true);
       setHideStep(0);
-      if (onFail) {
-        onFail();
-      }
     }
   };
+
+  useEffect(() => {
+    if (failed && hideStep >= 4 && onFail) {
+      onFail();
+    }
+  }, [failed, hideStep, onFail]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- trigger site hiding after Wordle fail once the gate has disappeared
- fade out nav, text, and background sequentially
- expose `className` for `Nav` and `FloatingLinks`
- add generic `.fade-out` CSS helper

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685084da34b8832b9b726a54ad657eae