### PR TITLE
Add fixed background to resume page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -85,6 +85,20 @@ html,body{
   align-items: center;
 }
 
+/* Background for resume page */
+.resumeBackground {
+  background-image: url('../public/loganbackgroundresume.png');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  min-height: 100vh;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 
 
 .introHeader {

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -238,7 +238,7 @@ export default function Resume() {
   }, [sorted]);
 
   return (
-    <>
+    <div className="resumeBackground">
     <div className="timeline-wrapper">
       <div
         className="resume-toggle"
@@ -362,7 +362,7 @@ export default function Resume() {
       </div>
     </div>
     <ExperienceModal exp={selected} onClose={() => setSelected(null)} />
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add `resumeBackground` CSS class for the resume page
- wrap Resume component content with new background container

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508d2367bc832b8d448ae517481c6b