### PR TITLE
Fix resume background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -525,7 +525,12 @@ html,body{
   margin-top: 0;
   height: 180vh;      /* adjust scroll length */
   width: 100%;
-  background: #e9ecef;
+  background-image: url('../public/loganbackgroundresume.png');
+  background-color: #e9ecef;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
   overflow-x: hidden;
   transition: opacity 0.3s ease;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -61,6 +61,15 @@ html,body{
   scroll-snap-type: y mandatory;
 }
 
+body.resume-background {
+  background-image: url('../public/loganbackgroundresume.png');
+  background-color: #e9ecef;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+}
+
 /* BootStrap */
 .jumboSpacing {
   padding-top: 0;
@@ -525,12 +534,7 @@ html,body{
   margin-top: 0;
   height: 180vh;      /* adjust scroll length */
   width: 100%;
-  background-image: url('../public/loganbackgroundresume.png');
-  background-color: #e9ecef;
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
-  background-attachment: fixed;
+  background: #e9ecef;
   overflow-x: hidden;
   transition: opacity 0.3s ease;
 }

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -139,6 +139,13 @@ export default function Resume() {
   const [scrollOffset, setScrollOffset] = useState(0);
 
   useEffect(() => {
+    document.body.classList.add("resume-background");
+    return () => {
+      document.body.classList.remove("resume-background");
+    };
+  }, []);
+
+  useEffect(() => {
     const onScroll = () => {
       const scrollTop =
         window.pageYOffset ||


### PR DESCRIPTION
## Summary
- use a fixed background image for the timeline on the resume page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508f042b40832bb42b3367a50c3a1f