### PR TITLE
Update skills section with tabs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -241,7 +241,7 @@ body.resume-background {
 .aboutMeDiv {
   margin: 6%;
   margin-bottom: -4%;
-  width: 80%;
+  width: 70%;
   display: flex;
   flex-wrap: wrap;
   gap: 4rem; /* increased spacing between About and Skills sections */
@@ -252,7 +252,7 @@ body.resume-background {
 .about-description {
   background-color: rgba(0, 0, 0, 0.4);
   padding: 1rem;
-  flex: 3 1 60%;
+  flex: 3 1 50%;
 }
 
 .skills-section {
@@ -262,8 +262,17 @@ body.resume-background {
   flex: 1 1 30%;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: flex-end;
+  text-align: right;
   justify-content: space-between; /* stretch content vertically */
+}
+
+.skill-buttons {
+  margin-bottom: 1rem;
+}
+
+.skill-buttons button {
+  margin-left: 0.5rem;
 }
 
 .contact-link {

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -14,11 +14,30 @@ const rotatingSkillList = [
   'Slack'
 ];
 
+const skillCategories = {
+  Development: [
+    'HTML',
+    'CSS',
+    'JavaScript'
+  ],
+  Marketing: [
+    'SEO',
+    'Email Campaigns',
+    'Analytics'
+  ],
+  'Content Creation': [
+    'Writing',
+    'Video Editing',
+    'Graphic Design'
+  ]
+};
+
 class Home extends Component{
 
   state = {
     rotatingSkills: [],
-    currentSkillIndex: 0
+    currentSkillIndex: 0,
+    selectedCategory: 'Development'
   }
 
   componentDidMount() {
@@ -39,13 +58,18 @@ class Home extends Component{
     clearInterval(this.interval);
   }
 
+  handleCategoryClick = (category) => {
+    this.setState({ selectedCategory: category });
+  }
+
   render(){
-    const { rotatingSkills, currentSkillIndex } = this.state;
+    const { rotatingSkills, currentSkillIndex, selectedCategory } = this.state;
     const { hideStep = -1 } = this.props;
     const currentSkill =
       rotatingSkills.length > 0
         ? rotatingSkills[currentSkillIndex]
         : rotatingSkillList[0];
+    const skills = skillCategories[selectedCategory];
     return (
         <div className="jumbotron jumbotron-fluid jumboSpacing">
           <div className={`backgroundImg ${hideStep >= 1 ? 'fade-out' : ''}`}>
@@ -70,8 +94,18 @@ class Home extends Component{
                 </div>
                 <div className="skills-section">
                   <h2>Skills</h2>
+                  <div className="skill-buttons">
+                    {Object.keys(skillCategories).map(category => (
+                      <button
+                        key={category}
+                        onClick={() => this.handleCategoryClick(category)}
+                      >
+                        {category}
+                      </button>
+                    ))}
+                  </div>
                   <ul>
-                    {rotatingSkillList.map(skill => (
+                    {skills.map(skill => (
                       <li key={skill}>{skill}</li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- narrow about me column
- right-align Skills header and list
- add category buttons for different skill groups

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c9e4ddd8832bb38dd90778a0a1af