### PR TITLE
Refine skills layout on home page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -271,17 +271,23 @@ body.resume-background {
   flex: 1 1 30%;
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  text-align: right;
-  justify-content: space-between; /* stretch content vertically */
+}
+
+.skills-container {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
 .skill-buttons {
   display: flex;
-  margin-bottom: 1rem;
-  align-items: center;
-  justify-content: center;
-  align-self: center; /* center the button group within the skills section */
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 0 0 120px;
+}
+
+.skills-list {
+  flex: 1;
 }
 
 .skill-buttons button {

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -94,21 +94,25 @@ class Home extends Component{
                 </div>
                 <div className="skills-section">
                   <h2>Skills</h2>
-                  <div className="skill-buttons">
-                    {Object.keys(skillCategories).map(category => (
-                      <button
-                        key={category}
-                        onClick={() => this.handleCategoryClick(category)}
-                      >
-                        {category}
-                      </button>
-                    ))}
+                  <div className="skills-container">
+                    <div className="skill-buttons">
+                      {Object.keys(skillCategories).map(category => (
+                        <button
+                          key={category}
+                          onClick={() => this.handleCategoryClick(category)}
+                        >
+                          {category}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="skills-list">
+                      <ul>
+                        {skills.map(skill => (
+                          <li key={skill}>{skill}</li>
+                        ))}
+                      </ul>
+                    </div>
                   </div>
-                  <ul>
-                    {skills.map(skill => (
-                      <li key={skill}>{skill}</li>
-                    ))}
-                  </ul>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- split skills section into button column and skills list
- update styles for new skills layout

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685351bcd91c832bba2291b200afde9f