### PR TITLE
Improve home mobile styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1046,6 +1046,41 @@ body.resume-background {
   }
 }
 
+/* Additional tuning for very small screens */
+@media (max-width: 480px) {
+  .skill-flash-text,
+  .firstName,
+  .lastName {
+    font-size: clamp(2rem, 16vw, 3rem);
+  }
+
+  .aboutMeDiv {
+    width: 90%;
+    gap: 2rem;
+  }
+
+  .about-description,
+  .skills-section {
+    padding: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .skills-container {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .skill-buttons {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .skill-buttons button {
+    margin: 0.25rem;
+  }
+}
+
 /* Wordle gate styles */
 .wordle-gate-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- adjust hero text for very small screens
- tweak About Me and Skills sections for mobile layout

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853632ed754832bb6a9c7e12e6ebf44