### PR TITLE
Fix resume tile zoom by restoring dynamic timeline height

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -267,7 +267,10 @@ export default function Resume() {
           Education
         </button>
       </div>
-      <div className={`timeline ${fading ? "fading" : ""}`}>
+      <div
+        className={`timeline ${fading ? "fading" : ""}`}
+        style={{ height: `${(sorted.length + 1) * 100}vh` }}
+      >
       {/* Spine */}
       <div className="spine" />
 


### PR DESCRIPTION
## Summary
- make resume timeline height dynamic again to allow scrolling

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853663516e0832bbb4b5677a4f11f8e