### PR TITLE
Fix resume toggle visibility

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -157,7 +157,6 @@ export default function Resume() {
   const [view, setView] = useState("career");
   const [fading, setFading] = useState(false);
   const [atTop, setAtTop] = useState(true);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
   useEffect(() => {
     document.body.classList.add("resume-background");
@@ -174,7 +173,6 @@ export default function Resume() {
         document.body.scrollTop ||
         0;
       setAtTop(scrollTop < 50);
-      setScrollOffset(scrollTop);
     };
     window.addEventListener("scroll", onScroll, { passive: true });
     onScroll();
@@ -269,8 +267,7 @@ export default function Resume() {
     <>
     <div className="timeline-wrapper">
       <div
-        className="resume-toggle"
-        style={{ transform: `translateX(${scrollOffset}px)` }}
+        className={`resume-toggle${atTop ? '' : ' slide-out'}`}
       >
         <button
           type="button"


### PR DESCRIPTION
## Summary
- ensure the resume toggle doesn't translate off screen
- hide toggle when scrolled down using CSS class

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854addfef40832b960807fc79dae701