### PR TITLE
Fix resume toggle visibility on return

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -165,6 +165,12 @@ export default function Resume() {
     };
   }, []);
 
+  // Ensure toggle is visible when returning to the page
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "auto" });
+    setAtTop(true);
+  }, []);
+
   useEffect(() => {
     const onScroll = () => {
       const scrollTop =


### PR DESCRIPTION
## Summary
- always scroll to top and reset toggle state when loading the resume page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854af095c64832b9e46f4e4a9ee6ee4