### PR TITLE
Fix mobile zoom

### DIFF
--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -239,7 +239,6 @@ export default function Resume() {
 
   // 5) Magnify cards on scroll and adjust connector lengths
   useLayoutEffect(() => {
-    if (window.innerWidth <= 640) return;
 
     const cardWidth = 280;
     let rafId;


### PR DESCRIPTION
## Summary
- remove mobile width check so timeline zoom works

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854be2e02cc832b8388270f24daec70