### PR TITLE
Fix mobile alignment in nav and skills section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -342,7 +342,7 @@ body.resume-background {
   .customNavLinks {
     display: none;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     position: absolute;
     top: 100%;
     left: 0;
@@ -350,6 +350,9 @@ body.resume-background {
     background-color: white;
     padding: 1rem;
     gap: 0.5rem;
+  }
+  .skills-container {
+    align-items: center;
   }
   .customNavLinks.showMobileMenu {
     display: flex;
@@ -1085,6 +1088,7 @@ body.resume-background {
   .skills-container {
     flex-direction: column;
     gap: 0.5rem;
+    align-items: center;
   }
   .mobileMenuButton {
     margin-right: 40px;


### PR DESCRIPTION
## Summary
- center nav items when mobile menu is opened
- center items in the skills container on smaller screens

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bfa06ab0832bb12af2d481bb4060